### PR TITLE
[OWL-528] Use Alpine as base image to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN \
   apk add --no-cache tzdata bash \
   && cp /usr/share/zoneinfo/Asia/Taipei /etc/localtime \
   && echo "Asia/Taipei" > /etc/timezone \
-  && apk del tzdata \
   && echo "alias ps='pstree'" > ~/.bashrc \
   && mkdir -p $CONFIGDIR
 
@@ -19,9 +18,9 @@ RUN apk add --no-cache python-dev py-virtualenv py-mysqldb
 ADD $PACKFILE $WORKDIR
 COPY $CONFIGFILE $CONFIGDIR/
 RUN \
-  ln -snf $CONFIGDIR/$CONFIGFILE $WORKDIR/frame/$CONFIGFILE && \
-  virtualenv $WORKDIR/env && \
-  pip install -r $WORKDIR/pip_requirements.txt
+  ln -snf $CONFIGDIR/$CONFIGFILE $WORKDIR/frame/$CONFIGFILE \
+  && virtualenv $WORKDIR/env \
+  && pip install -r $WORKDIR/pip_requirements.txt
 
 WORKDIR $WORKDIR
 COPY run.sh $WORKDIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,15 @@ MAINTAINER minimum@cepave.com
 
 ENV WORKDIR=/home/links PACKFILE=falcon-links.tar.gz CONFIGDIR=/config CONFIGFILE=config.py
 
-# Volume 
-VOLUME $CONFIGDIR
-
-# Set timezone & bash
+# Set timezone, bash, config dir
 # Set alias in the case of user want to execute control in their terminal
 RUN \
   apk add --no-cache tzdata bash \
   && cp /usr/share/zoneinfo/Asia/Taipei /etc/localtime \
   && echo "Asia/Taipei" > /etc/timezone \
   && apk del tzdata \
-  && echo "alias ps='pstree'" > ~/.bashrc
+  && echo "alias ps='pstree'" > ~/.bashrc \
+  && mkdir -p $CONFIGDIR
 
 # Install Open-Falcon Links Component
 RUN apk add --no-cache python-dev py-virtualenv py-mysqldb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM alpine:3.4
 
 MAINTAINER minimum@cepave.com
 
@@ -7,10 +7,17 @@ ENV WORKDIR=/home/links PACKFILE=falcon-links.tar.gz CONFIGDIR=/config CONFIGFIL
 # Volume 
 VOLUME $CONFIGDIR
 
-# Install Open-Falcon Links Component
+# Set timezone & bash
+# Set alias in the case of user want to execute control in their terminal
 RUN \
-  apt-get update && \
-  apt-get install -y python-virtualenv python-dev python-mysqldb
+  apk add --no-cache tzdata bash \
+  && cp /usr/share/zoneinfo/Asia/Taipei /etc/localtime \
+  && echo "Asia/Taipei" > /etc/timezone \
+  && apk del tzdata \
+  && echo "alias ps='pstree'" > ~/.bashrc
+
+# Install Open-Falcon Links Component
+RUN apk add --no-cache python-dev py-virtualenv py-mysqldb
 ADD $PACKFILE $WORKDIR
 COPY $CONFIGFILE $CONFIGDIR/
 RUN \
@@ -18,11 +25,11 @@ RUN \
   virtualenv $WORKDIR/env && \
   pip install -r $WORKDIR/pip_requirements.txt
 
-WORKDIR /root
-COPY run.sh ./
+WORKDIR $WORKDIR
+COPY run.sh $WORKDIR
 
 # Port
 EXPOSE 5090
 
 # Start
-CMD ["./run.sh"]
+CMD ["bash", "run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+APP="falcon-links"
 WAIT_SERVICE_READY=10
 
 function check_service(){
@@ -13,11 +14,10 @@ function check_service(){
 }
 
 $WORKDIR/control restart
-sleep $WAIT_SERVICE_READY
-check_service
-if [ $? -eq 0 ] ; then
-  $WORKDIR/control tail
-else
-  echo "Failed to start."
-  exit 1
-fi
+while sleep $WAIT_SERVICE_READY; do
+  check_service
+  if [ $? -eq 1 ] ; then
+    echo "$APP exited"
+    exit 1
+  fi
+done

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,26 @@
 #!/bin/bash
 
+#
+# Note that this file should be put under the same directory
+# with control script for 2 reasons:
+#
+# 1. This file sets the alias then source the script to
+#     retain the setting for the purpose of making control
+#     script work normally on Alpine without modification.
+# 2. The control script will change its working directory.
+#
+
 APP="falcon-links"
 WAIT_SERVICE_READY=10
 
-function check_service(){
-  status=$($WORKDIR/control status)
+# Expand alias to make control compatible with Alpine
+alias ps='pstree'
+shopt -s expand_aliases
+
+check_service()
+{
+  # Source the script to retain the alias
+  status=$(source $WORKDIR/control status)
   echo $status | grep -q "stoped"
   if [ $? -eq 0 ] ; then
     return 1
@@ -13,7 +29,8 @@ function check_service(){
   fi
 }
 
-$WORKDIR/control restart
+# Source the script to retain the alias
+source $WORKDIR/control restart
 while sleep $WAIT_SERVICE_READY; do
   check_service
   if [ $? -eq 1 ] ; then


### PR DESCRIPTION
Replace ubuntu with alpine as base image.
Use alias in running script to solve the control compatibility problem.
Remove VOLUME to avoid the change discarded problem.
